### PR TITLE
fix(enabled-file-types): add git commit file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
             "csharp",
             "css",
             "git-commit",
+            "gitcommit",
             "go",
             "handlebars",
             "haskell",


### PR DESCRIPTION
After creating [this](https://github.com/iamcco/coc-spell-checker/issues/49#issue-1402307984) issue, I did a little research and found that the file type of `COMMIT_EDITMSG` file is `"gitcommit"` (by doing `:echo &filetype` in NeoVim). But in the `package.json` file, it's `"git-commit"`. I just added the `"gitcommit"` file type and kept the old one as is because, I'm not sure if it's correct for other platforms or different versions of vim.